### PR TITLE
yt-dlp upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thread-keeper",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "thread-keeper",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thread-keeper",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "",
   "main": "app.js",
   "type": "module",

--- a/scripts/download-yt-dlp.sh
+++ b/scripts/download-yt-dlp.sh
@@ -1,3 +1,3 @@
-# Pulls yt-dlp (2023.01.06 version) and saves it in `executables`.
-curl -L https://github.com/yt-dlp/yt-dlp/releases/download/2023.01.06/yt-dlp > ../executables/yt-dlp;
+# Pulls yt-dlp (2023.02.17 version) and saves it in `executables`.
+curl -L https://github.com/yt-dlp/yt-dlp/releases/download/2023.02.17/yt-dlp > ../executables/yt-dlp;
 chmod a+x ../executables/yt-dlp;


### PR DESCRIPTION
- Upgrade to yt-dlp [2023.02.17](https://github.com/yt-dlp/yt-dlp/releases/tag/2023.02.17)
- Version bump