### PR TITLE
fix: create empty certs.json when it doesn't exist

### DIFF
--- a/app/utils/CertsHistory.js
+++ b/app/utils/CertsHistory.js
@@ -50,8 +50,10 @@
 
     const filepath = type === "signing" ? CertsHistory.signingFilepath : CertsHistory.timestampingFilepath;
 
-    if (!fs.readFileSync(filepath)) {
-      fs.writeFileSync(filepath, "{}");
+    try {
+      fs.readFileSync(filepath)
+    } catch (err) {
+      fs.writeFileSync(filepath, "{}")
     }
 
     return JSON.parse(fs.readFileSync(filepath));


### PR DESCRIPTION
Hello! I'm new here 👋

I was running thread-keeper locally and came across a bug.

**Reproduce**:
Visit `http://127.0.0.1:3000/check` with no `signing-certs-history.json` (or `timestamping-certs-history.json`) in `DATA_PATH`

<img width="661" alt="Screen Shot 2023-06-28 at 17 59 17" src="https://github.com/harvard-lil/thread-keeper/assets/5404230/36d30daa-6a4b-4dcc-923c-8d03b647c72c">


**Cause**:
`if (!fs.readFileSync(filepath)) {` throws an error when `filepath` doesn't exist.

**Fix**:
Wrap in a try-catch
- `signing-certs-history.json` and `timestamping-certs-history.json` are created
- page displays as expected

<img width="657" alt="Screen Shot 2023-06-28 at 17 58 31" src="https://github.com/harvard-lil/thread-keeper/assets/5404230/f02d3330-3358-4a51-b816-c7c45cbb0e15">





